### PR TITLE
Tr/add record

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ build:
 	docker build --network=host -t tsar .
 
 # rebuild, start shell in container
-shell_no_build:
+shell:
 	docker run \
-		--name tsar \
+		--name tsar_shell \
 		-e HOST_USER=${USER} \
 		--rm \
 		-it \
@@ -21,19 +21,16 @@ shell_no_build:
 		tsar \
 		bash
 
-shell: build shell_no_build
-
 # rebuild, run app in container
-dev_no_build:
+run:
 	docker run \
-		--name tsar_dev \
-		-it \
+		--name tsar \
 		-e HOST_USER=${USER} \
 		--rm \
-		--volume="$(shell pwd):/opt" \
+		-itd \
+		--volume="$(shell pwd):/opt:cached" \
 		--volume="${HOME}/.ipython:/root/.ipython:cached" \
 		--memory="2g" \
+		--detach-keys="ctrl-c" \
 		tsar \
 		bash
-
-dev: build dev_no_build

--- a/Makefile
+++ b/Makefile
@@ -7,30 +7,34 @@
 build:
 	docker build --network=host -t tsar .
 
-# rebuild, start shell in container
-shell:
+# rebuild, run app in container
+run: build
 	docker run \
-		--name tsar_shell \
+		-p 8888:8888 \
+		--name tsar \
 		-e HOST_USER=${USER} \
+		-e HOST_DIR=$(shell pwd) \
+		-e HOST_HOME=${HOME} \
 		--rm \
-		-it \
+		-idt \
 		--volume="$(shell pwd):/opt:cached" \
 		--volume="${HOME}/.ipython:/root/.ipython:cached" \
 		--memory="2g" \
-		--detach-keys="ctrl-c" \
 		tsar \
 		bash
 
-# rebuild, run app in container
-run:
+# services command line arguments from host
+shell: build
 	docker run \
+		-p 8888:8888 \
 		--name tsar \
 		-e HOST_USER=${USER} \
+		-e HOST_DIR=$(shell pwd) \
+		-e HOST_HOME=${HOME} \
 		--rm \
-		-itd \
+		-idt \
 		--volume="$(shell pwd):/opt:cached" \
 		--volume="${HOME}/.ipython:/root/.ipython:cached" \
 		--memory="2g" \
-		--detach-keys="ctrl-c" \
 		tsar \
 		bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ ipython
 nltk
 numpy
 pandas
+paramiko
 prompt_toolkit
 pygments
 pygments-style-solarized

--- a/resources/elasticsearch/jvm.options
+++ b/resources/elasticsearch/jvm.options
@@ -19,8 +19,8 @@
 # Xms represents the initial size of total heap space
 # Xmx represents the maximum size of total heap space
 
--Xms1g
--Xmx1g
+-Xms2g
+-Xmx2g
 
 ################################################################
 ## Expert settings

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,11 @@
+# /bin/bash
+NAME='tsar'
+TSAR_PATH="/Users/trensink/git/my_repos/tsar/"
+
+# start "run" container if not running already
+[[ $(docker ps -f "name=$NAME" --format '{{.Names}}') == $NAME ]] ||
+(cd $TSAR_PATH && make run)
+
+docker attach tsar --detach-keys="ctrl-v"
+# see: https://tldp.org/HOWTO/Keyboard-and-Console-HOWTO-4.html
+echo -e \\033c

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 # /bin/bash
 NAME='tsar'
-TSAR_PATH="/Users/trensink/git/my_repos/tsar/"
+TSAR_PATH="$(pwd)"
 
 # start "run" container if not running already
 [[ $(docker ps -f "name=$NAME" --format '{{.Names}}') == $NAME ]] ||

--- a/scripts/macos/attach.sh
+++ b/scripts/macos/attach.sh
@@ -1,4 +1,9 @@
 # /bin/bash
+NAME='tsar'
+
+# conditionally start container
+[[ $(docker ps -f "name=$NAME" --format '{{.Names}}') == $NAME ]] ||
+(cd ../../ && make run)
 
 docker attach tsar --detach-keys="ctrl-c"
 # see: https://tldp.org/HOWTO/Keyboard-and-Console-HOWTO-4.html

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -114,8 +114,8 @@ def test_client_index_drop():
 def test_collection_new():
     """test collection creation."""
     Collection.db_path = TEST_DB_META_PATH
+    Collection.drop_db_meta()
     Collection.create_db_meta()
-    # Collection.db_meta = pd.read_pickle(TEST_DB_META_PATH)
     coll = Collection.new(
         collection_name=TEST_COLLECTION_NAME,
         RecordDef=WikiRecord,
@@ -158,6 +158,7 @@ def test_collection_remove_record():
 
 def test_collection_drop():
     """Test deleting a collection."""
+    Collection.db_path = TEST_DB_META_PATH
     Collection.drop(
         collection_name=TEST_COLLECTION_NAME, folder=TEST_COLLECTIONS_FOLDER,
     )

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -15,13 +15,13 @@ import pandas as pd
 from tsar.lib.collection import Data, Collection
 from tsar.lib.record_defs.wiki_record import WikiRecord
 from tsar.lib.search import Client, Server
-from tsar import TESTS_FOLDER
+from tsar import HOST_TESTS_FOLDER
 
 TEST_COLLECTIONS_FOLDER = "/tmp/test_Collections/"
 TEST_DATA_FOLDER = "/tmp/test_Data/"
 TEST_COLLECTION_NAME = "test_collection"
-TEST_DB_META_PATH = TEST_COLLECTIONS_FOLDER + "meta_df.pkl"
-FIXTURES_FOLDER = os.path.join(TESTS_FOLDER, "fixtures")
+TEST_DB_META_PATH = TEST_COLLECTIONS_FOLDER + "meta_db.pkl"
+FIXTURES_FOLDER = os.path.join(HOST_TESTS_FOLDER, "fixtures")
 WIKI_RECORD_ID = os.path.join(FIXTURES_FOLDER, "wiki_doc.md")
 TEST_INDEX = "test_index"
 Server().start()
@@ -113,22 +113,23 @@ def test_client_index_drop():
 
 def test_collection_new():
     """test collection creation."""
+    Collection.db_path = TEST_DB_META_PATH
+    Collection.create_db_meta()
+    # Collection.db_meta = pd.read_pickle(TEST_DB_META_PATH)
     coll = Collection.new(
         collection_name=TEST_COLLECTION_NAME,
         RecordDef=WikiRecord,
         folder=TEST_COLLECTIONS_FOLDER,
-        db_meta_path=TEST_DB_META_PATH,
     )
-    db_meta = pd.read_pickle(TEST_DB_META_PATH)
-    assert db_meta.equals(coll.db_meta)
+    coll_db = pd.read_pickle(TEST_DB_META_PATH)
+    assert coll_db.equals(coll.db_meta())
 
 
 def test_collection_init():
     """test adding document to collection."""
+    Collection.db_path = TEST_DB_META_PATH
     coll = Collection(
-        collection_name=TEST_COLLECTION_NAME,
-        folder=TEST_COLLECTIONS_FOLDER,
-        db_meta_path=TEST_DB_META_PATH,
+        collection_name=TEST_COLLECTION_NAME, folder=TEST_COLLECTIONS_FOLDER,
     )
     assert isinstance(coll, Collection)
 
@@ -136,9 +137,7 @@ def test_collection_init():
 def test_collection_add_document():
     """test adding document to collection."""
     coll = Collection(
-        collection_name=TEST_COLLECTION_NAME,
-        folder=TEST_COLLECTIONS_FOLDER,
-        db_meta_path=TEST_DB_META_PATH,
+        collection_name=TEST_COLLECTION_NAME, folder=TEST_COLLECTIONS_FOLDER,
     )
     num_records_init = coll.df.shape[0]
     coll.add_document(WIKI_RECORD_ID)
@@ -149,9 +148,7 @@ def test_collection_add_document():
 def test_collection_remove_record():
     """test adding document to collection."""
     coll = Collection(
-        collection_name=TEST_COLLECTION_NAME,
-        folder=TEST_COLLECTIONS_FOLDER,
-        db_meta_path=TEST_DB_META_PATH,
+        collection_name=TEST_COLLECTION_NAME, folder=TEST_COLLECTIONS_FOLDER,
     )
     num_records_init = coll.df.shape[0]
     coll.remove_record(WIKI_RECORD_ID)
@@ -162,9 +159,7 @@ def test_collection_remove_record():
 def test_collection_drop():
     """Test deleting a collection."""
     Collection.drop(
-        collection_name=TEST_COLLECTION_NAME,
-        folder=TEST_COLLECTIONS_FOLDER,
-        db_meta_path=TEST_DB_META_PATH,
+        collection_name=TEST_COLLECTION_NAME, folder=TEST_COLLECTIONS_FOLDER,
     )
     db_meta = pd.read_pickle(TEST_DB_META_PATH)
     assert TEST_COLLECTION_NAME not in db_meta.index

--- a/tsar/__init__.py
+++ b/tsar/__init__.py
@@ -3,6 +3,7 @@ paths
 """
 import os
 
+# all paths as seen on CONTAINER:
 MODULE_PATH = __path__[0]
 REPO_PATH = os.path.split(MODULE_PATH)[0]
 RESOURCES_PATH = os.path.join(REPO_PATH, "resources/")
@@ -12,7 +13,13 @@ CAPTURE_DOC_PATH = os.path.join(RESOURCES_PATH, "capture.md")
 
 # _TEMP_METADB_PATH = METADB_PATH
 _TEMP_CONTENT_FOLDER = os.path.join(REPO_PATH, ".tmp_content")
-
 TESTS_FOLDER = os.path.join(REPO_PATH, "tests")
+
+
+# All paths as seen on HOST machine
+HOST_REPO_PATH = os.environ["HOST_DIR"]
+# HOST_REPO_PATH = os.path.split(HOST_MODULE_PATH)[0]
+HOST_RESOURCES_PATH = os.path.join(HOST_REPO_PATH, "resources/")
+HOST_TESTS_FOLDER = os.path.join(HOST_REPO_PATH, "tests")
 
 del os

--- a/tsar/app/add_document_window.py
+++ b/tsar/app/add_document_window.py
@@ -156,6 +156,8 @@ class AddDocumentViewModel(object):
         """
         # this tries to preview the record; will fail if slow
         try:
+            import random
+
             record = self.RecordDef.gen_record(self.input_text)
             summary_text = record["record_summary"]
             self.preview_textcontrol.buffer.text = summary_text

--- a/tsar/app/add_document_window.py
+++ b/tsar/app/add_document_window.py
@@ -35,7 +35,7 @@ class AddDocumentViewModel(object):
         )
         # callback function that links input to results:
         self.input_buffer.on_text_changed += self.update_results
-        self.results_textcontrol = FormattedTextControl("(no results)")
+        self.results_textcontrol = FormattedTextControl("")
         self.preview_header = BufferControl(focusable=False,)
         self.preview_header.buffer.text = "DOCUMENT PREVIEW"
 
@@ -154,12 +154,15 @@ class AddDocumentViewModel(object):
         - signature required to be callable from prompt_toolkit callback
 
         """
-        pass
-        # try:
-        #     record = self.RecordDef.gen_record(self.input_text)
-        #     self.preview_textcontrol.buffer.text = "something here"
-        # except ValueError:
-        #     self.preview_textcontrol.buffer.text = "nothing here"
+        # this tries to preview the record; will fail if slow
+        try:
+            record = self.RecordDef.gen_record(self.input_text)
+            summary_text = record["record_summary"]
+            self.preview_textcontrol.buffer.text = summary_text
+        except Exception as e:
+            self.preview_textcontrol.buffer.text = "(unable to generate record) " + str(
+                random.random()
+            )
 
     def add_document(self, record_id):
         """Add document associated with record_id.

--- a/tsar/app/add_document_window.py
+++ b/tsar/app/add_document_window.py
@@ -160,7 +160,6 @@ class AddDocumentViewModel(object):
         except Exception:
             results = "(no results found)"
         self.results_textcontrol.text = results
-
         self.preview_textcontrol.buffer.text = preview
 
     def add_document(self, input_buffer, state=[0]):

--- a/tsar/app/add_document_window.py
+++ b/tsar/app/add_document_window.py
@@ -30,7 +30,7 @@ class AddDocumentViewModel(object):
         self.input_buffer.on_text_changed += self.update_results
         self.results_textcontrol = FormattedTextControl("")
         self.preview_header = BufferControl(focusable=False,)
-        self.preview_header.buffer.text = "DOCUMENT PREVIEW"
+        self.preview_header.buffer.text = "preview"
 
         self.preview_textcontrol = BufferControl(
             focusable=False,
@@ -181,7 +181,7 @@ class AddDocumentViewModel(object):
 
 
 class AddDocumentView(object):
-    """Bind input, visual elements to search_view_model logic. """
+    """Bind input, visual elements to add_doc_view_model logic. """
 
     def __init__(self, add_document_view_model):
 
@@ -251,13 +251,13 @@ class AddDocumentView(object):
 
 def title_bar_text(shared_state):
     """return text for title bar, updated when screen changes."""
-    # cols = shared_state["active_collection"].df.columns
-    title_str = "Add document to: {}".format(shared_state["active_collection"].name)
+    collection_name = shared_state["active_collection"].name
+    title_str = f"ADD: {collection_name}"
     return title_str
 
 
 if __name__ == "__main__":
-    """stand-alone version of the search window for debugging."""
+    """stand-alone version of the add_document window for debugging."""
 
     shared_state = {
         "active_collection": Collection(DEFAULT_COLLECTION),

--- a/tsar/app/add_document_window.py
+++ b/tsar/app/add_document_window.py
@@ -24,7 +24,7 @@ class AddDocumentViewModel(object):
 
         self.shared_state = shared_state
         self.input_buffer = Buffer(
-            name="input_buffer", multiline=False, accept_handler=self.add_document
+            name="input_buffer", multiline=False, accept_handler=self.add_document,
         )
         # callback function that links input to results:
         self.input_buffer.on_text_changed += self.update_results
@@ -151,12 +151,17 @@ class AddDocumentViewModel(object):
         """call back function updates results when input text changes
         - signature required to be callable from prompt_toolkit callback
         """
-        documents_preview = self.RecordDef.preview_documents(self.input_text)
-        # self.input_text = str(self.RecordDef)
-        self.results_textcontrol.text = documents_preview
+        try:
+            preview = self.RecordDef.preview_document(self.input_text)
+        except Exception:
+            preview = "(no preview available)"
+        try:
+            results = self.RecordDef.preview_documents(self.input_text)
+        except Exception:
+            results = "(no results found)"
+        self.results_textcontrol.text = results
 
-        document_preview = self.RecordDef.preview_document(self.input_text)
-        self.preview_textcontrol.buffer.text = document_preview
+        self.preview_textcontrol.buffer.text = preview
 
     def add_document(self, input_buffer, state=[0]):
         """Add document associated with record_id.

--- a/tsar/app/app.py
+++ b/tsar/app/app.py
@@ -101,7 +101,7 @@ class App(object):
         def open_capture(event):
             open_textfile(path=CAPTURE_DOC_PATH, editor=EDITOR)
 
-        @kb_global.add("c-a")
+        @kb_global.add(GLOBAL_KB["add_document"])
         def add_screen(event):
             self.update_state("add_document")
 

--- a/tsar/app/app.py
+++ b/tsar/app/app.py
@@ -7,6 +7,7 @@ This module contains high level management of the terminal interface:
 from tsar import CAPTURE_DOC_PATH
 from tsar.lib.collection import Collection
 from tsar.app.search_window import SearchView, SearchViewModel
+from tsar.app.add_document_window import AddDocumentView, AddDocumentViewModel
 from tsar.app.collections_window import CollectionsView, CollectionsViewModel
 from tsar.config import GLOBAL_KB, DEFAULT_COLLECTION, DEFAULT_SCREEN, EDITOR
 from prompt_toolkit.key_binding import KeyBindings, merge_key_bindings
@@ -71,6 +72,11 @@ class App(object):
                 ViewModel=SearchViewModel,
                 View=SearchView,
             ),
+            "add_document": Screen(
+                shared_state=self.shared_state,
+                ViewModel=AddDocumentViewModel,
+                View=AddDocumentView,
+            ),
         }
         self.update_state(initial_screen_name)
         self.shared_state["active_screen"] = self.screens[initial_screen_name]
@@ -94,6 +100,10 @@ class App(object):
         @kb_global.add(GLOBAL_KB["open_capture_doc"])
         def open_capture(event):
             open_textfile(path=CAPTURE_DOC_PATH, editor=EDITOR)
+
+        @kb_global.add("c-w")
+        def add_screen(event):
+            self.update_state("add_document")
 
         return kb_global
 

--- a/tsar/app/app.py
+++ b/tsar/app/app.py
@@ -48,7 +48,7 @@ class App(object):
         initial_collection_name=DEFAULT_COLLECTION,
         initial_screen_name=DEFAULT_SCREEN,
     ):
-        if "default_collection" not in Collection.db_meta.index:
+        if "default_collection" not in Collection.db_meta().index:
             Collection.new(collection_name="default_collection", RecordDef=WikiRecord)
 
         # mutable/updatable object references across app.

--- a/tsar/app/app.py
+++ b/tsar/app/app.py
@@ -53,6 +53,7 @@ class App(object):
 
         # mutable/updatable object references across app.
         self.shared_state = {
+            "Collection": Collection,
             "active_collection": Collection(initial_collection_name),
             "active_screen": None,
             "prev_screen": None,

--- a/tsar/app/app.py
+++ b/tsar/app/app.py
@@ -101,7 +101,7 @@ class App(object):
         def open_capture(event):
             open_textfile(path=CAPTURE_DOC_PATH, editor=EDITOR)
 
-        @kb_global.add("c-w")
+        @kb_global.add("c-a")
         def add_screen(event):
             self.update_state("add_document")
 

--- a/tsar/app/collections_window.py
+++ b/tsar/app/collections_window.py
@@ -30,7 +30,7 @@ class CollectionsViewModel(object):
         self.query_buffer.on_text_changed += self.update_results
         self.results_textcontrol = FormattedTextControl("(no results)")
         self.preview_header = BufferControl(focusable=False,)
-        self.preview_header.buffer.text = "RECORD PREVIEW"
+        self.preview_header.buffer.text = "preview"
 
         self.preview_textcontrol = BufferControl(
             focusable=False,
@@ -150,8 +150,7 @@ class CollectionsViewModel(object):
             self.index = 0
             self.status_textcontrol.text = (
                 f"showing {len(self.results)} of "
-                f"{self.shared_state['Collection'].db_meta().shape[0]} records.    "
-                f"(ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax)"
+                f"{self.shared_state['Collection'].db_meta().shape[0]} collections"
             )
 
     def select_collection(self):
@@ -165,16 +164,16 @@ class CollectionsViewModel(object):
 
 
 class CollectionsView(object):
-    """Bind input, visual elements to search_view_model logic. """
+    """Bind input, visual elements to collections_view_model logic. """
 
-    def __init__(self, search_view_model):
+    def __init__(self, collections_view_model):
 
-        self.view_model = search_view_model
+        self.view_model = collections_view_model
         self.shared_state = self.view_model.shared_state
 
         # layout components:
         self.query_header = Window(
-            FormattedTextControl(query_title_bar_text(self.shared_state)),
+            FormattedTextControl(return_title_bar_text(self.shared_state)),
             height=1,
             style="reverse",
         )
@@ -231,26 +230,23 @@ class CollectionsView(object):
             try:
                 self.view_model.select_collection()
             except Exception:
-                self.view_model.status_textcontrol.text = "(no doc selected)"
+                self.view_model.status_textcontrol.text = "(no collection selected)"
 
     def refresh_view(self):
         """Code when screen is changed."""
-        # self.view_model.query_str = ""
-        self.query_header.content.text = query_title_bar_text(self.shared_state)
+        self.query_header.content.text = return_title_bar_text(self.shared_state)
         self.view_model.update_results()
         self.layout.focus(self.query_window)
 
 
-def query_title_bar_text(shared_state):
+def return_title_bar_text(shared_state):
     """return text for title bar, updated when screen changes."""
-    collection_names = shared_state["Collection"].db_meta().index
-    collection_name_str = " | ".join(collection_names)
-    str_value = f"COLLECTIONS: {collection_name_str}"
+    str_value = f"COLLECTIONS"
     return str_value
 
 
 if __name__ == "__main__":
-    """stand-alone version of the search window for debugging."""
+    """stand-alone version of the collections window for debugging."""
 
     shared_state = {
         "Collection": Collection,

--- a/tsar/app/collections_window.py
+++ b/tsar/app/collections_window.py
@@ -99,7 +99,7 @@ if __name__ == "__main__":
     view_model = CollectionsViewModel(shared_state)
     view = CollectionsView(view_model)
 
-    @view.kb.add("c-c")
+    @view.kb.add("c-q")
     def _(event):
         event.app.exit()
 

--- a/tsar/app/collections_window.py
+++ b/tsar/app/collections_window.py
@@ -1,101 +1,264 @@
 """
-A simple example of a few buttons and click handlers.
+module for collections screen.
 """
+
 from __future__ import unicode_literals
 from prompt_toolkit.application import Application
 from prompt_toolkit.key_binding import KeyBindings
-from prompt_toolkit.key_binding.bindings.focus import (
-    focus_next,
-    focus_previous,
-)
-from prompt_toolkit.layout import HSplit, Layout
-from prompt_toolkit.widgets import Box, Button, Label
+from prompt_toolkit.layout.containers import HSplit, Window
+from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.layout.layout import Layout
+from prompt_toolkit.layout.controls import BufferControl
+from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.widgets import HorizontalLine
+from tsar.config import SEARCH_RECORD_COLORS, DEFAULT_COLLECTION
 from tsar.lib.collection import Collection
-from tsar.config import DEFAULT_COLLECTION
-from prompt_toolkit.key_binding import merge_key_bindings
+from prompt_toolkit.lexers import PygmentsLexer
+from prompt_toolkit.layout.processors import TabsProcessor
+from datetime import datetime
+from operator import itemgetter
 
 
 class CollectionsViewModel(object):
-    """Business logic for collections view"""
+    """View model/business logic for collections window (based on SearchViewModel)."""
 
-    def __init__(self, shared_state):
+    def __init__(self, shared_state, style=SEARCH_RECORD_COLORS):
 
         self.shared_state = shared_state
-        self.collection_names = tuple(shared_state["active_collection"].db_meta().index)
+        self.query_buffer = Buffer(name="query_buffer", multiline=False)
+        # callback function that links query to results:
+        self.query_buffer.on_text_changed += self.update_results
+        self.results_textcontrol = FormattedTextControl("(no results)")
+        self.preview_header = BufferControl(focusable=False,)
+        self.preview_header.buffer.text = "RECORD PREVIEW"
+
+        self.preview_textcontrol = BufferControl(
+            focusable=False,
+            input_processors=[TabsProcessor(tabstop=4, char1=" ", char2=" ")],
+        )
+        self.preview_textcontrol.buffer.text = "(no result selected)"
+        self.status_textcontrol = FormattedTextControl()
+        self.style = style
+        # value -1 indicates no result is currently selected
+        self._index = -1
+        self.results = []
+        # FormattedText results:
+        self.formatted_results = self._apply_default_format(self.results)
+        self.update_results()
+
+    @property
+    def query_str(self):
+        return self.query_buffer.text
+
+    @query_str.setter
+    def query_str(self, new_query_str):
+        """computes results when set
+        """
+        self.query_buffer.text = new_query_str
+
+    @property
+    def index(self):
+        return self._index
+
+    @index.setter
+    def index(self, new_index):
+        """defines the index (int) of the selected result
+        if no selected result, index=-1 (keeping type int makes life simpler)
+        """
+        old_index = self._index
+
+        L = len(self.results)
+        if L == 0:
+            new_index = -1
+        elif new_index < 0:
+            new_index = 0
+        elif L - 1 < new_index:
+            new_index = L - 1
+
+        self._index = new_index
+        self._update_preview_content()
+
+        # update results formatting
+        self._update_selected_result(old_index, new_index)
+
+    def _update_preview_content(self):
+        """Update preview content based on index."""
+        if self.index == -1:
+            preview_str = "(no result selected)"
+        else:
+            record = (
+                self.shared_state["Collection"].db_meta().loc[self.results[self.index]]
+            )
+            preview_str = str(record)
+        self.preview_textcontrol.buffer.text = preview_str
+
+    def _update_selected_result(self, old_index, new_index):
+        """update formatted results style based on index change.
+
+        old or new index may be -1 or no longer exist
+        """
+        try:
+            self.formatted_results[old_index] = (
+                self.style["unselected"],
+                self.formatted_results[old_index][1],
+            )
+        except IndexError:
+            pass
+        try:
+            self.formatted_results[new_index] = (
+                self.style["selected"],
+                self.formatted_results[new_index][1],
+            )
+        except IndexError:
+            pass
+
+    def _apply_default_format(self, results_list):
+        """convert a list of result strings to a FormattedText object
+
+        print formatted results using print_formatted_text
+        """
+        if len(results_list) != 0:
+            result_names = results_list
+            results_list = [f"{res}\n" for res in result_names]
+            formatted_results = [
+                (self.style["unselected"], res) for res in results_list
+            ]
+        else:
+            formatted_results = []
+        return formatted_results
+
+    def update_results(self, passthrough="dummy_arg"):
+        """call back function updates results when query text changes
+        - signature required to be callable from prompt_toolkit callback
+
+        - set results based on query
+        - set formatted results (default formatting)
+        - update index to 0 (-1 if no results)
+            - updates selected record
+            - updates preview of selected record
+        - update status bar
+        """
+        try:
+            results = self.shared_state["Collection"].db_meta().index
+            self.results = sorted(results)
+        except Exception:
+            self.results = {}
+            self.status_textcontrol.text = "(invalid query)"
+        else:
+            self.formatted_results = self._apply_default_format(self.results)
+            self.results_textcontrol.text = self.formatted_results
+            self.index = 0
+            self.status_textcontrol.text = (
+                f"showing {len(self.results)} of "
+                f"{self.shared_state['Collection'].db_meta().shape[0]} records.    "
+                f"(ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax)"
+            )
+
+    def select_collection(self):
+        """Set active collection."""
+        if len(self.results) > 0:
+            collection = self.results[self.index]
+        else:
+            pass
+        self.shared_state["active_collection"] = Collection(collection_name=collection)
+        self._update_preview_content()
 
 
 class CollectionsView(object):
     """Bind input, visual elements to search_view_model logic. """
 
-    def __init__(self, collections_view_model):
+    def __init__(self, search_view_model):
 
-        self.view_model = collections_view_model
+        self.view_model = search_view_model
         self.shared_state = self.view_model.shared_state
-        collection_names = self.view_model.collection_names
 
-        # create buttons, bind function that returns their name when clicked.
-        buttons = []
-        for coll_name in collection_names:
-            handler = self._button_handler_factory(coll_name)
-            button = Button(f"{coll_name}", handler=handler)
-            buttons.append(button)
-            if coll_name == self.shared_state["active_collection"].name:
-                focused_element = button
+        # layout components:
+        self.query_header = Window(
+            FormattedTextControl(query_title_bar_text(self.shared_state)),
+            height=1,
+            style="reverse",
+        )
 
-        root_container = Box(
+        self.query_window = Window(
+            BufferControl(self.view_model.query_buffer,), height=1,
+        )
+        results_window = Window(self.view_model.results_textcontrol, height=13)
+
+        preview_header = Window(
+            self.view_model.preview_header, height=1, style="reverse"
+        )
+
+        preview_window = Window(
+            self.view_model.preview_textcontrol, height=22, wrap_lines=True
+        )
+        status_window = Window(
+            self.view_model.status_textcontrol, height=1, style="reverse"
+        )
+
+        # GENERATE LAYOUT
+        self.layout = Layout(
             HSplit(
                 [
-                    Label(text="Collections:"),
-                    Box(
-                        body=HSplit(buttons, padding=1),
-                        padding=2,
-                        style="class:left-pane",
-                    ),
+                    self.query_header,
+                    self.query_window,
+                    results_window,
+                    preview_header,
+                    preview_window,
+                    status_window,
                 ]
             ),
         )
 
-        self.layout = Layout(container=root_container, focused_element=focused_element)
-
-        # Key bindings.
+        # SEARCH PAGE KEYBINDINGS
         self.kb = KeyBindings()
-        self.kb.add("down")(focus_next)
-        self.kb.add("up")(focus_previous)
 
-    def _button_handler_factory(self, collection_name):
-        """Create handlers to bind to each button when pressed."""
+        # select result:
+        @self.kb.add("up")
+        def _(event):
+            self.view_model.index -= 1
 
-        def handler():
-            self.shared_state["active_collection"] = Collection(collection_name)
-            # if "collections" is first screen, there will be no prev_screen
-            if self.shared_state["prev_screen"] is None:
-                self.shared_state["prev_screen"] = self.shared_state["active_screen"]
-            self.shared_state["active_screen"] = self.shared_state["prev_screen"]
-            self.shared_state["application"].layout = self.shared_state[
-                "active_screen"
-            ].layout
-            self.shared_state["application"].key_bindings = merge_key_bindings(
-                [
-                    self.shared_state["active_screen"].key_bindings,
-                    self.shared_state["global_kb"],
-                ]
-            )
-            self.shared_state["active_screen"].refresh_view()
+        @self.kb.add("down")
+        def _(event):
+            self.view_model.index += 1
 
-        return handler
+        @self.kb.add("escape")
+        def _(event):
+            self.view_model.query_str = ""
+
+        @self.kb.add("enter")
+        def _(event):
+            """set active collection"""
+            try:
+                self.view_model.select_collection()
+            except Exception:
+                self.view_model.status_textcontrol.text = "(no doc selected)"
 
     def refresh_view(self):
-        pass
+        """Code when screen is changed."""
+        # self.view_model.query_str = ""
+        self.query_header.content.text = query_title_bar_text(self.shared_state)
+        self.view_model.update_results()
+        self.layout.focus(self.query_window)
+
+
+def query_title_bar_text(shared_state):
+    """return text for title bar, updated when screen changes."""
+    collection_names = shared_state["Collection"].db_meta().index
+    collection_name_str = " | ".join(collection_names)
+    str_value = f"COLLECTIONS: {collection_name_str}"
+    return str_value
 
 
 if __name__ == "__main__":
-    """stand-alone version of the collections window for debugging."""
+    """stand-alone version of the search window for debugging."""
 
     shared_state = {
+        "Collection": Collection,
         "active_collection": Collection(DEFAULT_COLLECTION),
         "active_screen": None,
         "application": Application(),
     }
+
     view_model = CollectionsViewModel(shared_state)
     view = CollectionsView(view_model)
 

--- a/tsar/app/collections_window.py
+++ b/tsar/app/collections_window.py
@@ -21,7 +21,7 @@ class CollectionsViewModel(object):
     def __init__(self, shared_state):
 
         self.shared_state = shared_state
-        self.collection_names = tuple(shared_state["active_collection"].db_meta.index)
+        self.collection_names = tuple(shared_state["active_collection"].db_meta().index)
 
 
 class CollectionsView(object):

--- a/tsar/app/search_window.py
+++ b/tsar/app/search_window.py
@@ -40,7 +40,7 @@ class SearchViewModel(object):
         self.query_buffer.on_text_changed += self.update_results
         self.results_textcontrol = FormattedTextControl("(no results)")
         self.preview_header = BufferControl(focusable=False,)
-        self.preview_header.buffer.text = "RECORD PREVIEW"
+        self.preview_header.buffer.text = "preview"
 
         self.preview_textcontrol = BufferControl(
             focusable=False,
@@ -182,8 +182,8 @@ class SearchViewModel(object):
             self.index = 0
             self.status_textcontrol.text = (
                 f"showing {len(self.results)} of "
-                f"{self.shared_state['active_collection'].df.shape[0]} records.    "
-                f"(ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax)"
+                f"{self.shared_state['active_collection'].df.shape[0]} records   "
+                f"syntax: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax)"
             )
 
     def open_selected(self):
@@ -282,8 +282,8 @@ def query_title_bar_text(shared_state):
     mapping = client.return_fields(coll_name)
     map_fields = mapping.keys()
 
-    fields_str = " | ".join(map_fields)
-    str_value = f"QUERY    fields: {fields_str}"
+    fields_str = ", ".join(map_fields)
+    str_value = f"QUERY: {coll_name}  ({fields_str})"
     return str_value
 
 

--- a/tsar/app/search_window.py
+++ b/tsar/app/search_window.py
@@ -35,7 +35,6 @@ class SearchViewModel(object):
     def __init__(self, shared_state, style=SEARCH_RECORD_COLORS):
 
         self.shared_state = shared_state
-        self.RecordDef = self.shared_state["active_collection"].RecordDef
         self.query_buffer = Buffer(name="query_buffer", multiline=False)
         # callback function that links query to results:
         self.query_buffer.on_text_changed += self.update_results
@@ -58,6 +57,11 @@ class SearchViewModel(object):
         # FormattedText results:
         self.formatted_results = self._apply_default_format(self.results)
         self.update_results()
+
+    @property
+    def RecordDef(self):
+        record_def = self.shared_state["active_collection"].RecordDef
+        return record_def
 
     @property
     def query_str(self):

--- a/tsar/config.py
+++ b/tsar/config.py
@@ -12,11 +12,12 @@ DEFAULT_SCREEN = "search"
 
 # GLOBAL KEY BINDINGS
 GLOBAL_KB = {
-    "exit": "c-q",
-    "search_screen": ("c-right"),
-    "collections_screen": ("c-left"),
+    "exit": "c-c",
+    "collections_screen": ("c-a"),
+    "add_document": ("c-d"),
+    "search_screen": ("c-s"),
+    "open_capture_doc": ("c-z"),
     "open_document": "enter",
-    "open_capture_doc": ("c-a"),
 }
 
 # STYLING

--- a/tsar/lib/collection.py
+++ b/tsar/lib/collection.py
@@ -138,6 +138,14 @@ class Collection(object):
             db_meta.to_pickle(cls.db_path)
 
     @classmethod
+    def drop_db_meta(cls):
+        """Remove db_meta at specified path if it exists."""
+        if os.path.exists(cls.db_path):
+            os.remove(cls.db_path)
+        else:
+            print(f"no db_meta found at {cls.db_path}")
+
+    @classmethod
     def new(
         cls, collection_name, RecordDef, folder=COLLECTIONS_FOLDER,
     ):
@@ -184,8 +192,8 @@ class Collection(object):
         except Exception:
             print("unable to locate collection db.")
         try:
-            cls.db_meta().drop(collection_name, inplace=True)
-            cls.db_meta().to_pickle(cls.db_path)
+            df = cls.db_meta().drop(collection_name)
+            df.to_pickle(cls.db_path)
         except Exception:
             print("unable to update db_meta.")
         try:

--- a/tsar/lib/collection.py
+++ b/tsar/lib/collection.py
@@ -121,6 +121,7 @@ class Collection(object):
             db_meta = pd.read_pickle(cls.db_path)
         except FileNotFoundError:
             print(f"no db found at {cls.db_path}")
+            db_meta = None
         return db_meta
 
     @classmethod

--- a/tsar/lib/collection.py
+++ b/tsar/lib/collection.py
@@ -9,6 +9,7 @@ import pandas as pd
 from tsar import COLLECTIONS_FOLDER
 from tsar.lib import search
 from tsar.lib.record_def import RecordDef
+from tsar.lib import ssh_utils
 
 # must be imported to be recognized as subclasses...
 from tsar.lib.record_defs.wiki_record import WikiRecord
@@ -103,6 +104,7 @@ class Collection(object):
 
     client = search.Client()
     search.Server().start()
+    ssh_client = ssh_utils.SSHClient()
     db_meta_path = DB_META_PATH
     try:
         db_meta = pd.read_pickle(db_meta_path)

--- a/tsar/lib/record_def.py
+++ b/tsar/lib/record_def.py
@@ -72,6 +72,16 @@ class SafeSerializer(JSONSerializer):
 class RecordDef(ABC):
     """The abstract base class that defines the interface for a record."""
 
+    @classmethod
+    @abstractmethod
+    def preview_document(preview_str):
+        pass
+
+    @classmethod
+    @abstractmethod
+    def preview_documents(preview_str):
+        pass
+
     @staticmethod
     @abstractmethod
     def gen_record(self, file):

--- a/tsar/lib/record_defs/arxiv_def.py
+++ b/tsar/lib/record_defs/arxiv_def.py
@@ -104,6 +104,16 @@ class ArxivRecord(RecordDef):
     preview_lexer = MarkdownLexer
     preview_style = style_from_pygments_cls(get_style_by_name("solarizeddark"))
 
+    @classmethod
+    def preview_document(cls, preview_str):
+        """"""
+        return "no preview available"
+
+    @classmethod
+    def preview_documents(cls, preview_str):
+        """"""
+        return "no preview available"
+
     @staticmethod
     def gen_record(document_id):
         """Parse doc_id (url) into record and return it.

--- a/tsar/lib/record_defs/arxiv_def.py
+++ b/tsar/lib/record_defs/arxiv_def.py
@@ -70,7 +70,7 @@ def recent_ml_and_ai_query_url(
 def gen_record_from_arxiv(arxiv_dict):
     """Parse arxiv package result into a record."""
     abstract = arxiv_dict["summary"]
-    title = arxiv_dict["title"]
+    title = arxiv_dict["title"].replace("\n", "")
     curr_time = parse_lib.utc_now_timestamp()
 
     keyword_text = "{} {}".format(title, abstract)

--- a/tsar/lib/record_defs/parse_lib.py
+++ b/tsar/lib/record_defs/parse_lib.py
@@ -52,12 +52,11 @@ def return_file_contents(path_string, sftp_client=None):
 
 
 def list_folder_contents(path_string, sftp_client=None):
-    """Return contents of longest valid folder on remote host.
+    """Return contents of longest valid folder on host.
 
-    E.g.,  ./git/my_re -> <contents of ./git>
+    E.g.,  ./git/xxxx -> <list of files in ./git>
     """
     path_string = resolve_path(path_string, sftp_client)
-
     if not sftp_client:
         sftp_client = SSHClient().open_sftp()
 
@@ -65,9 +64,7 @@ def list_folder_contents(path_string, sftp_client=None):
         contents_list = sftp_client.listdir(path_string)
     except FileNotFoundError:
         contents_list = sftp_client.listdir(path_string.rsplit("/", 1)[0])
-
-    contents_str = "\n".join(contents_list)
-    return contents_str
+    return contents_list
 
 
 def return_files(folder, extensions=None, sftp_client=None):
@@ -89,7 +86,7 @@ def return_files(folder, extensions=None, sftp_client=None):
     return paths
 
 
-def open_textfile(path, editor, sftp_client=None):
+def open_textfile(path, editor, ssh_client=None):
     """Open text file with editor."""
     if not ssh_client:
         ssh_client = SSHClient()
@@ -103,16 +100,6 @@ def open_url(url, browser, sftp_client=None):
         ssh_client = SSHClient()
     cmd = f"open -a {browser} {url} && osascript -e 'tell application \"{browser}\" to activate'"
     ssh_client.exec_command(cmd)
-
-
-def return_raw_doc(path, sftp_client=None):
-    """Return text doc as a string."""
-    if not sftp_client:
-        sftp_client = SSHClient().open_sftp()
-    # cmd = f"{SSH_TO_HOST} test -f {path} && cat {path}"
-    # proc = subprocess.run(cmd, shell=True, stdout=PIPE)
-    # text = proc.stdout.decode()
-    # return text
 
 
 def file_base_features(path, record_type):

--- a/tsar/lib/record_defs/wiki_record.py
+++ b/tsar/lib/record_defs/wiki_record.py
@@ -9,6 +9,7 @@ from tsar.lib.record_defs import parse_lib
 from pygments.lexers.markup import MarkdownLexer
 from prompt_toolkit.styles.pygments import style_from_pygments_cls
 from pygments.styles import get_style_by_name
+from tsar.lib.ssh_utils import SSHClient
 
 SERIALIZER = SafeSerializer()
 
@@ -43,6 +44,7 @@ VALID_EXTENSIONS = (".md",)
 class WikiRecord(RecordDef):
     """Defines wiki doc -> wiki_record and downstream processing."""
 
+    ssh_client = SSHClient()
     record_type = RECORD_TYPE
     base_schema = BASE_SCHEMA
     schema = SCHEMA
@@ -51,12 +53,30 @@ class WikiRecord(RecordDef):
     preview_lexer = MarkdownLexer
     preview_style = style_from_pygments_cls(get_style_by_name("solarizeddark"))
 
+    @classmethod
+    def preview_document(cls, preview_str):
+        """Preview available files based on host path (e.g. ls -A1)."""
+        document_preview = parse_lib.return_file_contents(
+            preview_str, ssh_client=WikiRecord.ssh_client
+        )
+        return document_preview
+
+    @classmethod
+    def preview_documents(cls, preview_str):
+        """Preview available files based on host path (e.g. ls -A1)."""
+
+        preview_str = f"{preview_str}*"
+        documents_preview = parse_lib.list_folder_contents(
+            preview_str, ssh_client=WikiRecord.ssh_client
+        )
+        return documents_preview
+
     @staticmethod
     def gen_record(path):
         """Parse doc into a record; return it."""
-        record_id = parse_lib.resolve_path(path)
-        record_id = str(record_id)
-
+        # record_id = parse_lib.resolve_path(path)
+        # record_id = str(record_id)
+        record_id = path
         raw_doc = parse_lib.return_raw_doc(record_id)
         file_info = parse_lib.file_meta_data(record_id)
 

--- a/tsar/lib/record_defs/wiki_record.py
+++ b/tsar/lib/record_defs/wiki_record.py
@@ -13,6 +13,7 @@ from tsar.lib.ssh_utils import SSHClient
 
 SERIALIZER = SafeSerializer()
 
+
 RECORD_TYPE = "wiki"
 
 SCHEMA = {
@@ -44,7 +45,7 @@ VALID_EXTENSIONS = (".md",)
 class WikiRecord(RecordDef):
     """Defines wiki doc -> wiki_record and downstream processing."""
 
-    ssh_client = SSHClient()
+    sftp_client = SSHClient().open_sftp()
     record_type = RECORD_TYPE
     base_schema = BASE_SCHEMA
     schema = SCHEMA
@@ -57,7 +58,7 @@ class WikiRecord(RecordDef):
     def preview_document(cls, preview_str):
         """Preview available files based on host path (e.g. ls -A1)."""
         document_preview = parse_lib.return_file_contents(
-            preview_str, ssh_client=WikiRecord.ssh_client
+            preview_str, sftp_client=WikiRecord.sftp_client
         )
         return document_preview
 
@@ -65,19 +66,18 @@ class WikiRecord(RecordDef):
     def preview_documents(cls, preview_str):
         """Preview available files based on host path (e.g. ls -A1)."""
 
-        preview_str = f"{preview_str}*"
+        preview_str = f"{preview_str}"
         documents_preview = parse_lib.list_folder_contents(
-            preview_str, ssh_client=WikiRecord.ssh_client
+            preview_str, sftp_client=WikiRecord.sftp_client
         )
+        documents_preview = "\n".join(documents_preview)
         return documents_preview
 
     @staticmethod
     def gen_record(path):
         """Parse doc into a record; return it."""
-        # record_id = parse_lib.resolve_path(path)
-        # record_id = str(record_id)
-        record_id = path
-        raw_doc = parse_lib.return_raw_doc(record_id)
+        record_id = parse_lib.resolve_path(path)
+        raw_doc = parse_lib.return_file_contents(record_id)
         file_info = parse_lib.file_meta_data(record_id)
 
         record = {}


### PR DESCRIPTION
- `add_document_window.py`: reuse query window format for adding documents to collection
  - preview_document, preview_documents  RecordDef ABC 
- `collections_window.py`: move collections to same format as other windows
- paramiko ssh, sftp clients to connect to host
- modified start/connection process:
  - $`tsar` # on host; starts docker container
  - $`tsar`  # in container; starts tsar app
  - $`ctrl+v` # from running app; disconnects
  - $`tsar` # from host; reconnect to running app instance
- minor refactor of `Collection`.  Modify `cls.db_meta` -> `cls.db_meta()` to allow update when `cls.db_meta_path` is changed.  anything `meta` should get moved out of Collection.
- fixed bug: `self.RecordDef = self.shared_state["active_collection"].RecordDef` does not update when active_collection changes.
- some parse_lib functionality not implemented with sftp server