### PR TITLE
revised port number to 8137

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ run: build
 
 shell: build
 	docker run \
-		-p 8888:8888 \
+		-p 8137:8137 \
 		--name tsar \
 		-e HOST_USER=${USER} \
 		-e HOST_DIR=$(shell pwd) \


### PR DESCRIPTION
port no `8888` binds with, among other things jupyter.  Collisions on `8137` should be less likely.