### PR TITLE
add host file server and support for adding local files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN ln -s /usr/bin/python3.7 /usr/bin/python && python -m pip install --upgrade 
 # expose cli client, es ports:
 EXPOSE 8137
 EXPOSE 8138
+EXPOSE 8139
 
 # copy requirements, creat python path
 WORKDIR $APP_PATH

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
+aiohttp
 apscheduler
 arxiv
 bs4
 elasticsearch
 flask
 flask-restful
+fsspec
 fuzzywuzzy
 html2text
 ipdb

--- a/run.sh
+++ b/run.sh
@@ -5,10 +5,11 @@ tsar_folder="$(dirname "$(readlink "$0")")"
 container='tsar'
 nargs="$#"
 
-# if tsar is not running, start it
+# if tsar is not running, start it and local file server
 if ! [ "$(docker ps -f "name=$container" --format '{{.Names}}')" = "$container" ]; then
 echo "starting tsar..."
-(cd $tsar_folder && docker compose up -d app)
+(cd $tsar_folder && docker compose up -d app && \
+python3 -m http.server 8139 --bind 127.0.0.1 --directory $HOME &)
 fi
 
 # if tsar already running, no args provided, attach to container

--- a/tsar/app/rest.py
+++ b/tsar/app/rest.py
@@ -74,7 +74,6 @@ def return_flask_app(tsar_app):
         )
         """
         data = request.json
-        print(data)
         document_id = data["document_id"]
         collection = tsar_app.state["collections"][collection]
         try:

--- a/tsar/doctypes/doctype.py
+++ b/tsar/doctypes/doctype.py
@@ -100,7 +100,8 @@ class DocType(ABC):
 
 
 class DocTypeManager(object):
-    """Define record generation and link management when multiple doc types are present."""
+    """Resolve document type given document_id."""
+
     def __init__(self, doctypes):
         self.doctypes = doctypes
 
@@ -135,6 +136,6 @@ class DocTypeManager(object):
     def resolve_document_id(self, link_id, doc_type=None):
         """Resolve document_id using doctype_resolver for link ids."""
         if doc_type is None:
-            doctype = self.return_doctype(document_id)
+            doctype = self.return_doctype(link_id)
         resolved_doc_id = doc_type.resolve_id(link_id)
         return resolved_doc_id

--- a/tsar/doctypes/markdown_doc.py
+++ b/tsar/doctypes/markdown_doc.py
@@ -84,15 +84,13 @@ class MarkdownDoc(DocType):
 
     @staticmethod
     def is_valid(document_id, extensions=[".md"]):
-        cond1 = os.path.exists(document_id)
+
+        cond1 = parse_lib.exists_on_fs(parse_lib.host_path_to_url(document_id))
         cond2 = os.path.splitext(document_id)[-1] in extensions
         return bool(cond1 and cond2)
 
     @staticmethod
     def preview(record):
 
-        preview_text = (
-            "(file contents):\n"
-            f'{record["content"]}'
-        )
+        preview_text = "(file contents):\n" f'{record["content"]}'
         return preview_text

--- a/tsar/lib/collection.py
+++ b/tsar/lib/collection.py
@@ -185,7 +185,9 @@ class Collection(object):
         Note:
         - init assigns attributes; use `Collection.new` etc. for collection creation.
         """
-        self.doctype_mgr = DocTypeManager({k:v for k,v in DOCTYPES.items() if v in doc_types})
+        self.doctype_mgr = DocTypeManager(
+            {k: v for k, v in DOCTYPES.items() if v in doc_types}
+        )
         self.collection_id = collection_id
         self.doc_types = doc_types
         self.records_db = records_db
@@ -408,16 +410,22 @@ class Collection(object):
                 logger.exception(f"unable to determine doc_type for {document_id}")
                 return
         try:
-            record = self.doctype_mgr.gen_record(document_id=document_id, primary_doc=primary_doc, gen_links=True)
+            record = self.doctype_mgr.gen_record(
+                document_id=document_id, primary_doc=primary_doc, gen_links=True
+            )
         except Exception:
-            logger.exception(f"Collection.gen_record failed for: document_id: {document_id}, doc_type: {doc_type}")
+            logger.exception(
+                f"Collection.gen_record failed for: document_id: {document_id}, doc_type: {doc_type}"
+            )
             return
 
         if gen_link_records:
             # don't overwrite primary documents as secondary
             link_id_set = set(record["links"]) - set(self.primary_documents())
             for link_id in list(link_id_set):
-                link_record = self.doctype_mgr.gen_record(document_id=link_id, primary_doc=False, gen_links=True)
+                link_record = self.doctype_mgr.gen_record(
+                    document_id=link_id, primary_doc=False, gen_links=True
+                )
                 self.add_record(link_record, index_linked_content=False, write=False)
         self.add_record(record, index_linked_content=True, write=write)
 
@@ -485,7 +493,9 @@ class Collection(object):
         )
         for document_id in document_ids:
             try:
-                self.add_document(document_id=document_id, doc_type=doc_type, write=False)
+                self.add_document(
+                    document_id=document_id, doc_type=doc_type, write=False
+                )
             except Exception as e:
                 print(f"error processing {document_id} as type {doc_type}:", e)
         if self.registered:
@@ -548,5 +558,7 @@ class Collection(object):
                 self._collection_id, doc_type_str=doc_type.__name__
             )
             self.client.index_record(
-                document_id=document_id, record_index=record_index, index_name=index_name
+                document_id=document_id,
+                record_index=record_index,
+                index_name=index_name,
             )


### PR DESCRIPTION
This MR completes *most* of the local filesystem integration.

Previously, the local (host) filesystem was mounted in the docker image for tsar to use directly; this caused the app to badly overheat and use significant CPU on mac.   As an alternative, an http file server is started on the host across an open port as needed.  `fsspec` is useful for reading from http server like a native file system.  

typical flow:
- `tsar add <coll> <fname>` is called from the host to add a local file/folder.  This issues a request to the docker container webserver defined in `rest.py`.
- if the document is a path on the host system, the fsspec client (fs) makes a request to the host file server and is added to the collection.


Details:
- the (host) file server is started in `run.sh`.  Shutdown of this server is not (yet) addressed.
- the fsspec client `fs` is created/used in parse_lib.py
- each `fs` call requires an url, whereas all saved paths should reflect the local file system
- paths relative to `cwd` on the host are not currently supported.  Currently supported path examples:
    - `Users/username/some/path/file.md`
    - `~some/path/file.md`